### PR TITLE
Refactor: raw and make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+myexip: myexip.o
+	$(CC) -o $@ $< $(shell pkg-config --libs libcurl)
+
+myexip.o: myexip.c
+	$(CC) -o $@ -c $(shell pkg-config --cflags libcurl) $<
+
+clean:
+	rm -f myexip myexip.o

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # myexip
-C cli to resolve external ipv4 and ipv6 using myexternalip.com
+cli to resolve external ipv4 and ipv6 using myexternalip.com
 
 ## Compile
 
-```bash
-gcc -lcurl -o myexip myexip.c
+```make
+make
 ```
+
+```bash
+cc -o myexip $(pkg-config --cflags libcurl) myexip.c $(pkg-config --libs libcurl)
+```
+
+Working compilers: gcc, clang
 
 ## Usage
 
@@ -13,7 +19,7 @@ gcc -lcurl -o myexip myexip.c
 $ ./myexip -h
 use: ./myexip [-6]
 
-$ ./myexip 
+$ ./myexip
 222.111.66.11
 
 $ ./myexip -6

--- a/myexip.c
+++ b/myexip.c
@@ -7,11 +7,11 @@
  *
  * usage:
  * ./myexip [-6] [-h]
- * 
+ *
  * inspired on
  * http://stackoverflow.com/questions/897027/i-want-to-store-a-result-for-character-string-with-libcurl
  * http://marc.info/?l=curl-library&m=100204184522546&w=2
- * 
+ *
  */
 
 #include <stdio.h>
@@ -20,63 +20,82 @@
 #include <unistd.h>
 #include <curl/curl.h>
 
-struct ip { char ip[64]; };
-struct ip myip; // global variable that will store ip
+struct str {
+    char*  bytes;
+    size_t len;
+};
 
-size_t  write_data(void *ptr, size_t size, size_t nmemb, FILE *stream){
-    char buf[size*nmemb+1];
-    char *pbuf = &buf[0];
-    memset(buf, '\0', size*nmemb+1);
-    for(size_t i = 0 ;  i < nmemb ; i++){
-        strncpy(pbuf, ptr, size);
-        pbuf += size;
-        ptr += size;
+static int str_append(struct str* s, const char* b, size_t len_b) {
+
+    const size_t len_total = s->len + len_b;
+    char* bytes = realloc(s->bytes, len_total);
+    if (bytes != NULL) {
+        s->bytes = bytes;
+        strncpy(s->bytes + s->len, b, len_b);
+        s->len = len_total;
+        return 1;
     }
-    char *str = "My-External-Ip: "; // the header we are looking for
-    size_t lenstr = strlen(str);
-    if (strncmp(buf, str, lenstr) == 0)
-        strncpy(myip.ip, buf+lenstr, sizeof(myip.ip));
-
-    return size * nmemb;
+    return 0;
 }
 
-int main(int argc, char **argv){
-    char *url = "http://ipv4.myexternalip.com"; // default to ipv4
-    long http_code = 0;
-    int c; // getopt counter
+static size_t store_http_body(void* ptr, size_t size, size_t nmemb, void* user) {
+
+    const size_t len = size * nmemb;
+    str_append((struct str*)user, (char*)ptr, len);
+    return len;
+}
+
+int main(int argc, char **argv) {
+
+    static const char USER_AGENT[] = "myexip/tiny c cli to myexip";
+    static const char V4_URL[]     = "http://ipv4.myexternalip.com/raw";
+    static const char V6_URL[]     = "http://ipv6.myexternalip.com/raw";
+
+    const char* url = V4_URL; // default to ipv4
+    long        http_code = 0;
+    int         c; // getopt counter
 
     opterr = 0;
     while ((c = getopt (argc, argv, "h6")) != -1){
         switch (c){
             case 'h':
                 printf("use: %s [-6]\n", argv[0]); // basic usage
-                exit(0);
+                return 0;
             case '6':
-                url = "http://ipv6.myexternalip.com"; // override to ipv6
+                url = V6_URL; // override to ipv6
                 break;
             case '?':
                 printf("unknown arg %c\n", optopt);
-                exit(1);
+                return 1;
         } // end switch
     } // end while
 
-    CURL *curl_handle;
+    CURL*       curl_handle;
+    CURLcode    res;
+    char        err_buf[CURL_ERROR_SIZE] = { 0 };
+    struct str  http_body = { NULL, 0 };
 
     curl_handle = curl_easy_init();
     curl_easy_setopt(curl_handle, CURLOPT_URL, url);
+    curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, USER_AGENT);
     curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1);
-    curl_easy_setopt(curl_handle, CURLOPT_HEADER, 1);
-    curl_easy_setopt(curl_handle, CURLOPT_NOBODY, 1);
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, &write_data);
-    curl_easy_perform(curl_handle);
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, store_http_body);
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void*)&http_body);
+    curl_easy_setopt(curl_handle, CURLOPT_ERRORBUFFER, err_buf);
+
+    res = curl_easy_perform(curl_handle);
     curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code);
 
-    if (CURLE_OK == 0 && http_code == 200 ){
-        printf("%s", myip.ip);
-    } else {
-        exit(1);
+    if (res == CURLE_OK && http_code == 200 ) {
+        write(1, http_body.bytes, http_body.len);
+        return 0;
     }
 
-    curl_easy_cleanup(curl_handle);
-    return 0;
+    if (strlen(err_buf) > 0) {
+        printf("libcurl: %s\n", err_buf);
+    } else {
+        printf("libcurl: %ld %s\n", http_code, url);
+    }
+
+    return 1;
 }


### PR DESCRIPTION
- switch to use http://myexternalip.com/raw instead of parsing the returned http-header.
- provide a Makefile
- better error-handling
